### PR TITLE
Feature/secure_strtok

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -79,7 +79,11 @@ int check_localport_gmail(char *localport) {
 int check_domain(char *mail) {
     int res = 0;
     //文字列をlocalportとdomainに分割
-    char *localport = strtok(mail, "@");
+    //strtokの使用には下記を参照
+    //https://www.jpcert.or.jp/sc-rules/c-str06-c.html
+    char *copy = (char *)malloc(strlen(mail) + 1);
+    strcpy(copy, mail);
+    char *localport = strtok(copy, "@");
     char *domain = strtok(NULL, "@");
     if (strcmp(domain, "gmail.com") == 0) {
         printf("これはGmailのメールアドレスです\n");


### PR DESCRIPTION
大きな修正ではないですがstrtokを安全に使用するよう修正しました。

strtokはそのまま使用すると分割対象文字列が変更されてしまう（今回のケースだとmailの変数）。
字句分割する文字列は、strtok() の呼び出し後には参照されない一時的な記憶域にコピーするように変更。

[STR06-C. strtok() が分割対象文字列を変更しないと想定しない](https://www.jpcert.or.jp/sc-rules/c-str06-c.html)